### PR TITLE
Use correct keys for measurement & label

### DIFF
--- a/src/components/ChartComponent.js
+++ b/src/components/ChartComponent.js
@@ -20,7 +20,7 @@ class ChartComponent extends Component {
 
   renderChart(measurements) {
     const data = measurements.map(measurement => measurement.inclusiveRenderDuration);
-    const labels = measurements.map(measurement => measuremen.key);
+    const labels = measurements.map(measurement => measurement.key);
     this.chart = new Chart(document.getElementById('perf-tool-chart-ctx'), {
       type: 'bar',
       data: {

--- a/src/components/ChartComponent.js
+++ b/src/components/ChartComponent.js
@@ -19,8 +19,8 @@ class ChartComponent extends Component {
   }
 
   renderChart(measurements) {
-    const data = measurements.map(measurement => measurement['Wasted time (ms)']);
-    const labels = measurements.map(measurement => measurement['Owner > component']);
+    const data = measurements.map(measurement => measurement.inclusiveRenderDuration);
+    const labels = measurements.map(measurement => measuremen.key);
     this.chart = new Chart(document.getElementById('perf-tool-chart-ctx'), {
       type: 'bar',
       data: {


### PR DESCRIPTION
Fixes #9 

The code expects a different data structure than what React 15.1.0 provides. Here's an example of objects logged to the console.

```
[
 {
   "key": "LazyList > ScribeNamespaceContainer",
   "instanceCount": 15,
   "inclusiveRenderDuration": 4.610000000007858,
   "renderCount": 40
 },
 {
   "key": "ScribeNamespaceContainer > ScribeProvider",
   "instanceCount": 15,
   "inclusiveRenderDuration": 2.085000000000946,
   "renderCount": 40
 },
 {
   "key": "ScribeNamespaceContainer > ScribePropsContainer",
   "instanceCount": 15,
   "inclusiveRenderDuration": 1.9400000000023283,
   "renderCount": 40
 },
 {
   "key": "LazyList > Waypoint",
   "instanceCount": 1,
   "inclusiveRenderDuration": 0.04499999999825377,
   "renderCount": 3
 }
]
```
